### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ A Model Context Protocol (MCP) server that lets you run AppleScript code to inte
 
 I can't believe how simple and powerful it is. The core code is <100 line of code.
 
+<a href="https://glama.ai/mcp/servers/@peakmojo/applescript-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@peakmojo/applescript-mcp/badge" alt="AppleScript Server MCP server" />
+</a>
+
 https://github.com/user-attachments/assets/b85e63ba-fb26-4918-8e6d-2377254ee388
 
 ## Features


### PR DESCRIPTION
This PR adds a badge for the [AppleScript MCP Server](https://glama.ai/mcp/servers/@peakmojo/applescript-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@peakmojo/applescript-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@peakmojo/applescript-mcp/badge" alt="AppleScript Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.